### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
         "RSV": "lib/RSV.rakumod"
     },
     "resources": [],
-    "license": "The MIT License",
+    "license": "MIT",
     "support": {
         "bugtracker": "https://github.com/gugod/raku-RSV/issues"
     },


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module